### PR TITLE
remove duplicate vectorTaxonId in InsecticideTreatedNetControlStrategy

### DIFF
--- a/src/main/resources/apollo-types_3.0.2.xsd
+++ b/src/main/resources/apollo-types_3.0.2.xsd
@@ -2658,8 +2658,6 @@
 		<complexContent>
 			<extension base="tns:VectorControlStrategy">
 				<sequence>
-					<element name="vectorTaxonId" type="tns:NcbiTaxonId"
-							 maxOccurs="1" minOccurs="0" />
 					<element name="netHolingRate" type="tns:LogNormalDistribution"
 							 maxOccurs="1" minOccurs="0" />
 					<element name="insecticideEfficacyDecayRate" type="tns:Rate"


### PR DESCRIPTION
vectorTaxonId repeated in InsecticideTreatedNetControlStrategy which is
already present in parent VectorControlStrategy, which violates
"Unique Particle Attribution"