### PR TITLE
alter regex for NcbiTaxonId to allow multiple digits

### DIFF
--- a/src/main/resources/apollo_types_3.1.0.xsd
+++ b/src/main/resources/apollo_types_3.1.0.xsd
@@ -1321,7 +1321,7 @@
     </complexType>
     <simpleType name="NcbiTaxonId">
         <restriction base="token">
-            <pattern value="[0-9]"/>
+            <pattern value="[0-9]+"/>
         </restriction>
     </simpleType>
     <simpleType name="SnomedId">


### PR DESCRIPTION
the previous pattern for NcbiTaxonId would not allow values with more
than one digit to pass schema validation.  xmllint would produce errors
like:

element taxonId: Schemas validity error : Element
'{http://types.apollo.pitt.edu/v3_1_0/}taxonId': [facet 'pattern'] The
value '9606' is not accepted by the pattern '[0-9]'

I don't believe that there is any upper bound on the NcbiTaxonId, but
that it is constrained to be a strictly positive integer

possible that other id patterns should be similarly changed (eg SnomedId, RxNormId, etc) 