### PR TITLE
make insecticide decay and holing rates optional

### DIFF
--- a/src/main/resources/apollo_types_3.1.0.xsd
+++ b/src/main/resources/apollo_types_3.1.0.xsd
@@ -1797,9 +1797,9 @@
         <complexContent>
             <extension base="tns:VectorControlMeasure">
                 <sequence>
-                    <element name="netHolingRate" type="tns:Rate" maxOccurs="1" minOccurs="1"/>
+                    <element name="netHolingRate" type="tns:Rate" maxOccurs="1" minOccurs="0"/>
                     <element name="nightlyProbabilityOfUse" type="tns:Probability" maxOccurs="1" minOccurs="1"/>
-                    <element name="insecticideEfficacyDecayRate" type="tns:Rate" maxOccurs="1" minOccurs="1"/>
+                    <element name="insecticideEfficacyDecayRate" type="tns:Rate" maxOccurs="1" minOccurs="0"/>
                 </sequence>
             </extension>
         </complexContent>


### PR DESCRIPTION
netHolingRate and insecticideEfficacyDecayRate are not required in Open Malaria, so make them optional in the XSD type.

