### PR TITLE
correct typo'd misspelling of inoculation

### DIFF
--- a/config-examples/src/main/java/edu/pitt/apollo/examples/runsimulationmessages/MalariaRunSimulationMessageBuilder.java
+++ b/config-examples/src/main/java/edu/pitt/apollo/examples/runsimulationmessages/MalariaRunSimulationMessageBuilder.java
@@ -63,9 +63,9 @@ public class MalariaRunSimulationMessageBuilder extends AbstractRunSimulationMes
 
         Rate eir = new Rate();
         eir.setValue(50d);
-        eir.setNumeratorUnitOfMeasure(UnitOfMeasureEnum.INNOCULATIONS);
+        eir.setNumeratorUnitOfMeasure(UnitOfMeasureEnum.INOCULATIONS);
         eir.setDenominatorUnitOfMeasure(UnitOfMeasureEnum.PER_INDIVIDUAL_PER_YEAR);
-        iafih.setInnoculationRate(eir);
+        iafih.setInoculationRate(eir);
 
         iafih.setInfectiousPeriodDuration(infectiousPeriod);
         iafih.setLatentPeriodDuration(latentPeriod);
@@ -77,9 +77,9 @@ public class MalariaRunSimulationMessageBuilder extends AbstractRunSimulationMes
 
         eir = new Rate();
         eir.setValue(75d);
-        eir.setNumeratorUnitOfMeasure(UnitOfMeasureEnum.INNOCULATIONS);
+        eir.setNumeratorUnitOfMeasure(UnitOfMeasureEnum.INOCULATIONS);
         eir.setDenominatorUnitOfMeasure(UnitOfMeasureEnum.PER_INDIVIDUAL_PER_YEAR);
-        iafih.setInnoculationRate(eir);
+        iafih.setInoculationRate(eir);
 
         iafih.setInfectiousPeriodDuration(infectiousPeriod);
         iafih.setLatentPeriodDuration(latentPeriod);
@@ -91,9 +91,9 @@ public class MalariaRunSimulationMessageBuilder extends AbstractRunSimulationMes
 
         eir = new Rate();
         eir.setValue(100d);
-        eir.setNumeratorUnitOfMeasure(UnitOfMeasureEnum.INNOCULATIONS);
+        eir.setNumeratorUnitOfMeasure(UnitOfMeasureEnum.INOCULATIONS);
         eir.setDenominatorUnitOfMeasure(UnitOfMeasureEnum.PER_INDIVIDUAL_PER_YEAR);
-        iafih.setInnoculationRate(eir);
+        iafih.setInoculationRate(eir);
 
         iafih.setInfectiousPeriodDuration(infectiousPeriod);
         iafih.setLatentPeriodDuration(latentPeriod);

--- a/src/main/resources/apollo_types_3.1.0.xsd
+++ b/src/main/resources/apollo_types_3.1.0.xsd
@@ -1020,7 +1020,7 @@
                 <element name="beta" type="tns:Rate" maxOccurs="1" minOccurs="1"/>
                 <element name="transmissionProbabilities" type="tns:TransmissionProbability" maxOccurs="unbounded" minOccurs="1"/>
                 <!-- <element name="forGlobalEpidemicSimulator" type="tns:GesParametersForContactAndTransmission"	maxOccurs="1" minOccurs="1" /> -->
-                <element name="innoculationRate" type="tns:Rate" maxOccurs="1" minOccurs="0"/>
+                <element name="inoculationRate" type="tns:Rate" maxOccurs="1" minOccurs="0"/>
             </choice>
         </sequence>
     </complexType>
@@ -1583,7 +1583,7 @@
             <enumeration value="daily_dose"/>
             <enumeration value="percent_of_population_vaccinated"/>
             <enumeration value="visits"/>
-            <enumeration value="innoculations"/>
+            <enumeration value="inoculations"/>
             <enumeration value="perIndividualPerYear"/>
             <enumeration value="house"/>
             <enumeration value="insecticideTreatedNets"/>


### PR DESCRIPTION
This should be a trivial change that should not have any far-reaching effects.

If possible, it would be better to use the correct spelling of inoculation, but if this will break other stuff, then it isn't worth it.